### PR TITLE
Added support for TI Launchpad

### DIFF
--- a/Sha/sha1.cpp
+++ b/Sha/sha1.cpp
@@ -5,7 +5,7 @@
 #define SHA1_K40 0x8f1bbcdc
 #define SHA1_K60 0xca62c1d6
 
-uint8_t sha1InitState[] PROGMEM = {
+static const uint8_t sha1InitState[] PROGMEM = {
   0x01,0x23,0x45,0x67, // H0
   0x89,0xab,0xcd,0xef, // H1
   0xfe,0xdc,0xba,0x98, // H2
@@ -94,7 +94,8 @@ void Sha1Class::pad() {
 }
 
 
-uint8_t* Sha1Class::result(void) {
+void Sha1Class::result(uint8_t* out)
+{
   // Pad to complete the last block
   pad();
   
@@ -109,8 +110,8 @@ uint8_t* Sha1Class::result(void) {
     state.w[i]=b;
   }
   
-  // Return pointer to hash (20 characters)
-  return state.b;
+  // Copy hash result to output buffer
+  memcpy(out, state.b, HASH_LENGTH);
 }
 
 #define HMAC_IPAD 0x36
@@ -135,7 +136,8 @@ void Sha1Class::initHmac(const uint8_t* key, int keyLength) {
   }
 }
 
-uint8_t* Sha1Class::resultHmac(void) {
+void Sha1Class::resultHmac(uint8_t* out)
+{
   uint8_t i;
   // Complete inner hash
   memcpy(innerHash,result(),HASH_LENGTH);
@@ -143,7 +145,8 @@ uint8_t* Sha1Class::resultHmac(void) {
   init();
   for (i=0; i<BLOCK_LENGTH; i++) write(keyBuffer[i] ^ HMAC_OPAD);
   for (i=0; i<HASH_LENGTH; i++) write(innerHash[i]);
-  return result();
+  
+  memcpy(out, state.b, HASH_LENGTH);
 }
 
 #if (defined(__linux) || defined(linux)) && !defined(__ARDUINO_X86__)

--- a/Sha/sha1.h
+++ b/Sha/sha1.h
@@ -2,14 +2,23 @@
 #define Sha1_h
 
 #include <string.h>
-#if  (defined(__linux) || defined(linux)) || defined(__ARDUINO_X86__)
+
+#if !defined(__linux) || !defined(linux)
+	#include "Arduino.h" //To bring in part.h for Energia
+#endif
+
+#if  (defined(__linux) || defined(linux)) || defined(__ARDUINO_X86__) || defined(__TM4C1294NCPDT__)
 	#define memcpy_P memcpy
 	#undef PROGMEM
-	#define PROGMEM __attribute__(( section(".progmem.data") ))
+	#ifndef __TM4C1294NCPDT__
+		#define PROGMEM __attribute__((section(".progmem.data")))
+	#else
+		#define PROGMEM __attribute__((section(".text")))
+	#endif
 	#define pgm_read_dword(p) (*(p))
-	#if defined(__ARDUINO_X86__)
+	#if defined(__ARDUINO_X86__) || defined(__TM4C1294NCPDT__)
 		#include "Print.h"
-	#endif	
+	#endif
 #else
 	#include <avr/io.h>
 	#include <avr/pgmspace.h>
@@ -38,8 +47,8 @@ class Sha1Class : public Print
   public:
     void init(void);
     void initHmac(const uint8_t* secret, int secretLength);
-    uint8_t* result(void);
-    uint8_t* resultHmac(void);
+    void result(uint8_t*);
+    void resultHmac(uint8_t*);
     #if  (defined(__linux) || defined(linux)) && !defined(__ARDUINO_X86__)
 	virtual size_t write(uint8_t);
 	size_t write_L(const char *str);

--- a/Sha/sha256.cpp
+++ b/Sha/sha256.cpp
@@ -109,7 +109,7 @@ void Sha256Class::pad() {
 }
 
 
-uint8_t* Sha256Class::result(void) {
+void Sha256Class::result(uint8_t* out) {
   // Pad to complete the last block
   pad();
   
@@ -124,8 +124,8 @@ uint8_t* Sha256Class::result(void) {
     state.w[i]=b;
   }
   
-  // Return pointer to hash (20 characters)
-  return state.b;
+  // Copy hash result to output buffer
+  memcpy(out, state.b, HASH_LENGTH);
 }
 
 #define HMAC_IPAD 0x36
@@ -153,7 +153,8 @@ void Sha256Class::initHmac(const uint8_t* key, int keyLength) {
   }
 }
 
-uint8_t* Sha256Class::resultHmac(void) {
+void Sha256Class::resultHmac(uint8_t* out)
+{
   uint8_t i;
   // Complete inner hash
   memcpy(innerHash,result(),HASH_LENGTH);
@@ -161,8 +162,10 @@ uint8_t* Sha256Class::resultHmac(void) {
   init();
   for (i=0; i<BLOCK_LENGTH; i++) write(keyBuffer[i] ^ HMAC_OPAD);
   for (i=0; i<HASH_LENGTH; i++) write(innerHash[i]);
-  return result();
+  
+  memcpy(out, state.b, HASH_LENGTH);
 }
+
 #if (defined(__linux) || defined(linux)) && !defined(__ARDUINO_X86__)
 	size_t Sha256Class::write_L(const char *str){
 		if (str == NULL) return 0;

--- a/Sha/sha256.h
+++ b/Sha/sha256.h
@@ -50,8 +50,8 @@ class Sha256Class : public Print
 public:
 	void init(void);
 	void initHmac(const uint8_t* secret, int secretLength);
-	uint8_t* result(void);
-	uint8_t* resultHmac(void);
+	void result(uint8_t*);
+	void resultHmac(uint8_t*);
 #if  (defined(__linux) || defined(linux)) && !defined(__ARDUINO_X86__) && !defined(__TM4C1294NCPDT__)
 	virtual size_t write(uint8_t);
 	size_t write_L(const char *str);


### PR DESCRIPTION
These additions add suport for TI Tiva C-Series Launchpad boards, in particular the EK-TM4C1294 Connected Launchpad. Support for others can be added very easily by simply adding another `defined(...)` clause in the header's `#if` statements. 

Also, the `result()` functions now take one argument: a user-supplied array of `byte` (that is, `unsigned char` or `uint8_t`) allocated to 32 bytes. Before, these functions returned a raw pointer to the SHA function's internal state, which could allow the user to accidentally (or intentionally) corrupt said state. Now the library copies bytes from the SHA's state to the user-supplied array. 
