### PR TITLE
write should return the number of successful bytes written

### DIFF
--- a/Sha/sha1.cpp
+++ b/Sha/sha1.cpp
@@ -72,7 +72,7 @@ void Sha1Class::addUncounted(uint8_t data) {
 size_t Sha1Class::write(uint8_t data) {
   ++byteCount;
   addUncounted(data);
-  return 0;
+  return 1;
 }
 
 void Sha1Class::pad() {

--- a/Sha/sha256.cpp
+++ b/Sha/sha256.cpp
@@ -87,7 +87,7 @@ void Sha256Class::addUncounted(uint8_t data) {
 size_t Sha256Class::write(uint8_t data) {
   ++byteCount;
   addUncounted(data);
-  return 0;
+  return 1;
 }
 
 void Sha256Class::pad() {


### PR DESCRIPTION
If I understand correctly, returning `0` signifies an error occurred, which may prevent `write` from receiving the entire buffer. 